### PR TITLE
Move code from the IJulia notebooks

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
 authors = ["Gilles Peiffer", "Benoît Legat", "Sascha Timme"]
 version = "0.1.0"
 
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
 [compat]
 julia = "1.1"
 

--- a/src/MutableArithmetics.jl
+++ b/src/MutableArithmetics.jl
@@ -8,10 +8,8 @@ module MutableArithmetics
 
 using LinearAlgebra, Base.GMP.MPZ
 
-import Base.+, Base.*, Base.==
-import LinearAlgebra.mul!
-
 export DummyBigInt
+export set_zero!, add_prod!
 
 
 """
@@ -38,9 +36,9 @@ Base.zero(::Type{DummyBigInt}) = DummyBigInt(0)
 Base.convert(::Type{DummyBigInt}, x::Int64) = DummyBigInt(x)
 
 # Arithmetics
-*(a::DummyBigInt, b::DummyBigInt) = DummyBigInt(a.data * b.data)
-+(a::DummyBigInt, b::DummyBigInt) = DummyBigInt(a.data + b.data)
-==(a::DummyBigInt, b::DummyBigInt) = a.data == b.data
+Base.:*(a::DummyBigInt, b::DummyBigInt) = DummyBigInt(a.data * b.data)
+Base.:+(a::DummyBigInt, b::DummyBigInt) = DummyBigInt(a.data + b.data)
+Base.:(==)(a::DummyBigInt, b::DummyBigInt) = a.data == b.data
 
 """
     add_prod!(x, args...)
@@ -80,9 +78,20 @@ Set the value of `x` to zero.
 """
 function set_zero! end
 
-set_zero!(x) = zero(x)
-set_zero!(x::BigInt) = MPZ.set_si!(x, 0)
-set_zero!(x::DummyBigInt) = set_zero!(x.data)
+function set_zero!(x)
+    x = zero(x)
+    x
+end
+
+function set_zero!(x::BigInt)
+    MPZ.set_si!(x, 0)
+    x
+end
+
+function set_zero!(x::DummyBigInt)
+    set_zero!(x.data)
+    x
+end
 
 """
     LinearAlgebra.mul!(C::AbstractVector, A::AbstractVecOrMat{T}, B::AbstractVector{T}) where {T <: AbstractMutable}
@@ -128,6 +137,6 @@ function mul(A::AbstractVecOrMat{T}, B::AbstractVector{T}) where {T<:AbstractMut
     mul!(C, A, B)
 end
 
-*(A::AbstractVecOrMat{T}, B::AbstractVector{T}) where {T<:AbstractMutable} = mul(A, B)
+Base.:*(A::AbstractVecOrMat{T}, B::AbstractVector{T}) where {T<:AbstractMutable} = mul(A, B)
 
 end # module

--- a/src/MutableArithmetics.jl
+++ b/src/MutableArithmetics.jl
@@ -1,5 +1,128 @@
+#  Copyright 2019, Gilles Peiffer, Benoît Legat, Sascha Timme, and contributors
+#  This Source Code Form is subject to the terms of the Mozilla Public
+#  License, v. 2.0. If a copy of the MPL was not distributed with this
+#  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+#############################################################################
+
 module MutableArithmetics
 
-greet() = print("Hello World!")
+using LinearAlgebra, Base.GMP.MPZ
+
+import Base.*, Base.promote_op, Base.==
+import LinearAlgebra.mul!
+
+export DummyBigInt
+
+
+"""
+    AbstractMutable
+
+Generic supertype for types
+implementing the MutableArithmetics interface.
+"""
+abstract type AbstractMutable end
+
+"""
+    DummyBigInt
+
+Mutable wrapper type around `BigInt`.
+"""
+struct DummyBigInt <: AbstractMutable
+    data::BigInt
+end
+
+# For convenience.
+Base.zero(::Type{DummyBigInt}) = DummyBigInt(0)
+Base.promote_op(matprod, ::Type{DummyBigInt}, ::Type{DummyBigInt}) = DummyBigInt
+Base.convert(::Type{DummyBigInt}, x::Int64) = DummyBigInt(x)
+==(a::DummyBigInt, b::DummyBigInt) = a.data == b.data
+
+"""
+    add_prod!(x, args...)
+
+Returns the result of `x + (*)(args...)` and possibly destroys
+`x` (i.e., reusing its storage for the result, if possible).
+"""
+function add_prod! end
+
+add_prod!(x, args...) = x + (*)(args...)
+
+function add_prod!(x::BigInt, a::BigInt, b::BigInt)
+    MPZ.add!(x, a*b)
+    x
+end
+
+function add_prod!(x::BigInt, a::BigInt, b::BigInt, buf::BigInt)
+    MPZ.mul!(buf, a, b)
+    MPZ.add!(x, buf)
+    x
+end
+
+function add_prod!(x::DummyBigInt, a::DummyBigInt, b::DummyBigInt)
+    add_prod!(x.data, a.data, b.data)
+    x
+end
+
+function add_prod!(x::DummyBigInt, a::DummyBigInt, b::DummyBigInt, buf::DummyBigInt)
+    add_prod!(x.data, a.data, b.data, buf.data)
+    x
+end
+
+"""
+    set_zero!(x)
+
+Set the value of `x` to zero.
+"""
+function set_zero! end
+
+set_zero!(x) = zero(x)
+set_zero!(x::BigInt) = MPZ.set_si!(x, 0)
+set_zero!(x::DummyBigInt) = set_zero!(x.data)
+
+"""
+    LinearAlgebra.mul!(C::AbstractVector, A::AbstractVecOrMat{T}, B::AbstractVector{T}) where {T <: AbstractMutable}
+
+Computes the product between a matrix of `AbstractMutable`s and a vector of `AbstractMutable`s.
+"""
+function LinearAlgebra.mul!(C::AbstractVector, A::AbstractVecOrMat{T}, B::AbstractVector{T}) where {T<:AbstractMutable}
+    # require_one_based_indexing is not exposed.
+    mB = length(B)
+    mA, nA = (size(A, 1), size(A, 2)) # lapack_size is not exposed.
+    if mB != nA
+        throw(DimensionMismatch("matrix A has dimensions ($mA,$nA), vector B has length $mB"))
+    end
+    if mA != length(C)
+        throw(DimensionMismatch("result C has length $(length(C)), needs length $mA"))
+    end
+
+    Astride = size(A, 1)
+    @inbounds begin
+    for i = 1:mA
+        set_zero!(C[i])
+    end
+
+    # We need a buffer to hold the intermediate multiplication.
+    mul_buffer = zero(T)
+    for k = 1:mB
+        aoffs = (k-1)*Astride
+        b = B[k]
+        for i = 1:mA
+            add_prod!(C[i], A[aoffs + i], b, mul_buffer)
+        end
+    end
+    end # @inbounds
+    C
+end
+
+function mul(A::AbstractVecOrMat{T}, B::AbstractVector{T}) where {T<:AbstractMutable}
+    C = similar(B, eltype(A), axes(A,1))
+    # C now contains only undefined values, we need to fill this with actual zeros
+    for i in eachindex(C)
+        C[i] = zero(eltype(A))
+    end
+    mul!(C, A, B)
+end
+
+*(A::AbstractVecOrMat{T}, B::AbstractVector{T}) where {T<:AbstractMutable} = mul(A, B)
 
 end # module

--- a/src/MutableArithmetics.jl
+++ b/src/MutableArithmetics.jl
@@ -8,7 +8,7 @@ module MutableArithmetics
 
 using LinearAlgebra, Base.GMP.MPZ
 
-import Base.*, Base.promote_op, Base.==
+import Base.+, Base.*, Base.==
 import LinearAlgebra.mul!
 
 export DummyBigInt
@@ -26,6 +26,8 @@ abstract type AbstractMutable end
     DummyBigInt
 
 Mutable wrapper type around `BigInt`.
+The goal of this type is to allow the package to test itself;
+hence its name.
 """
 struct DummyBigInt <: AbstractMutable
     data::BigInt
@@ -33,8 +35,11 @@ end
 
 # For convenience.
 Base.zero(::Type{DummyBigInt}) = DummyBigInt(0)
-Base.promote_op(matprod, ::Type{DummyBigInt}, ::Type{DummyBigInt}) = DummyBigInt
 Base.convert(::Type{DummyBigInt}, x::Int64) = DummyBigInt(x)
+
+# Arithmetics
+*(a::DummyBigInt, b::DummyBigInt) = DummyBigInt(a.data * b.data)
++(a::DummyBigInt, b::DummyBigInt) = DummyBigInt(a.data + b.data)
 ==(a::DummyBigInt, b::DummyBigInt) = a.data == b.data
 
 """

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,6 +4,27 @@ using MutableArithmetics
 using LinearAlgebra, Base.GMP.MPZ
 
 @testset "MutableArithmetics" begin
+    @testset "DummyBigInt arithmetics" begin
+        @test DummyBigInt(2) + DummyBigInt(3) == DummyBigInt(5)
+        @test DummyBigInt(2) * DummyBigInt(3) == DummyBigInt(6)
+    end
+
+    @testset "add_prod!" begin
+        buf = zero(BigInt)
+        dummy_buf = zero(DummyBigInt)
+        @test add_prod!(1, 2, 3) == 7
+        @test add_prod!(BigInt(1), BigInt(2), BigInt(3)) == BigInt(7)
+        @test add_prod!(BigInt(1), BigInt(2), BigInt(3), buf) == BigInt(7)
+        @test add_prod!(DummyBigInt(1), DummyBigInt(2), DummyBigInt(3)) == DummyBigInt(7)
+        @test add_prod!(DummyBigInt(1), DummyBigInt(2), DummyBigInt(3), dummy_buf) == DummyBigInt(7)
+    end
+
+    @testset "set_zero!" begin
+        @test set_zero!(1) == 0
+        @test set_zero!(BigInt(1)) == BigInt(0)
+        @test set_zero!(DummyBigInt(1)) == DummyBigInt(0)
+    end
+
     @testset "matrix-vector product" begin
         @test DummyBigInt[1 2; 3 4]*DummyBigInt[1; 1] == DummyBigInt[3; 7]
         @test_throws DimensionMismatch DummyBigInt[0 0; 0 0]*DummyBigInt[]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,12 @@
-using MutableArithmetics
 using Test
+using MutableArithmetics
 
-@testset "MutableArithmetics.jl" begin
-    # Write your own tests here.
+using LinearAlgebra, Base.GMP.MPZ
+
+@testset "MutableArithmetics" begin
+    @testset "matrix-vector product" begin
+        @test DummyBigInt[1 2; 3 4]*DummyBigInt[1; 1] == DummyBigInt[3; 7]
+        @test_throws DimensionMismatch DummyBigInt[0 0; 0 0]*DummyBigInt[]
+        @test_throws DimensionMismatch LinearAlgebra.mul!(DummyBigInt[], DummyBigInt[0 0; 0 0], DummyBigInt[0; 0])
+    end
 end


### PR DESCRIPTION
Adds the `LinearAlgebra.mul!` operation for types `<: AbstractMutable`, and the tests for it using `DummyBigInt`.