### PR TITLE
Refactor with operate functions

### DIFF
--- a/src/MutableArithmetics.jl
+++ b/src/MutableArithmetics.jl
@@ -7,6 +7,7 @@
 module MutableArithmetics
 
 include("interface.jl")
+include("shortcuts.jl")
 
 # Test that can be used to test an implementation of the interface
 include("Test/Test.jl")

--- a/src/Test/int.jl
+++ b/src/Test/int.jl
@@ -38,7 +38,7 @@ function int_mul_test(::Type{T}) where T
     end
 end
 function int_add_mul_test(::Type{T}) where T
-    @testset "add_mul_to! / add_mul! / add_mul_buf_to! /add_mul_buf!" begin
+    @testset "add_mul_to! / add_mul! / add_mul_buf_to! / add_mul_buf!" begin
         @test MA.mutability(T, MA.add_mul, T, T) isa MA.IsMutable
         @test MA.mutability(T, MA.add_mul, T, T, T) isa MA.IsMutable
         @test MA.mutability(T, MA.add_mul, T, T, T, T) isa MA.IsMutable

--- a/src/Test/int.jl
+++ b/src/Test/int.jl
@@ -1,7 +1,6 @@
 function int_add_test(::Type{T}) where T
     @testset "add_to! / add!" begin
-        @test MA.mutability(T, MA.add_to!, T, T) isa MA.IsMutable
-        @test MA.mutability(T, MA.add!, T) isa MA.IsMutable
+        @test MA.mutability(T, +, T, T) isa MA.IsMutable
 
         t(n) = convert(T, n)
         a = t(5)
@@ -21,8 +20,7 @@ function int_add_test(::Type{T}) where T
 end
 function int_mul_test(::Type{T}) where T
     @testset "mul_to! / mul!" begin
-        @test MA.mutability(T, MA.mul_to!, T, T) isa MA.IsMutable
-        @test MA.mutability(T, MA.mul!, T) isa MA.IsMutable
+        @test MA.mutability(T, *, T, T) isa MA.IsMutable
 
         t(n) = convert(T, n)
         a = t(5)
@@ -39,12 +37,11 @@ function int_mul_test(::Type{T}) where T
         @test a == t(420)
     end
 end
-function int_muladd_test(::Type{T}) where T
-    @testset "muladd_to! / muladd! / muladd_buf_to! /muladd_buf!" begin
-        @test MA.mutability(T, MA.muladd_to!, T, T, T) isa MA.IsMutable
-        @test MA.mutability(T, MA.muladd!, T, T) isa MA.IsMutable
-        @test MA.mutability(T, MA.muladd_buf_to!, T, T, T, T) isa MA.IsMutable
-        @test MA.mutability(T, MA.muladd_buf!, T, T, T) isa MA.IsMutable
+function int_add_mul_test(::Type{T}) where T
+    @testset "add_mul_to! / add_mul! / add_mul_buf_to! /add_mul_buf!" begin
+        @test MA.mutability(T, MA.add_mul, T, T) isa MA.IsMutable
+        @test MA.mutability(T, MA.add_mul, T, T, T) isa MA.IsMutable
+        @test MA.mutability(T, MA.add_mul, T, T, T, T) isa MA.IsMutable
 
         t(n) = convert(T, n)
         a = t(5)
@@ -53,16 +50,16 @@ function int_muladd_test(::Type{T}) where T
         d = t(20)
         buf = t(24)
 
-        @test MA.muladd_to!(a, b, c, d) == t(69)
+        @test MA.add_mul_to!(a, b, c, d) == t(69)
         @test a == t(69)
         a = t(5)
-        @test MA.muladd!(b, c, d) == t(69)
+        @test MA.add_mul!(b, c, d) == t(69)
         @test b == t(69)
         b = t(9)
 
-        @test MA.muladd_buf_to!(buf, a, b, c, d) == t(69)
+        @test MA.add_mul_buf_to!(buf, a, b, c, d) == t(69)
         @test a == t(69)
-        @test MA.muladd_buf!(buf, b, c, d) == t(69)
+        @test MA.add_mul_buf!(buf, b, c, d) == t(69)
         @test b == t(69)
 
         a = t(148)
@@ -70,19 +67,19 @@ function int_muladd_test(::Type{T}) where T
         c = t(17)
         d = t(42)
         buf = t(56)
-        @test MA.muladd!(a, b, c) == t(420)
+        @test MA.add_mul!(a, b, c) == t(420)
         @test a == t(420)
         a = t(148)
-        @test MA.muladd_buf_to!(buf, d, a, b, c) == t(420)
+        @test MA.add_mul_buf_to!(buf, d, a, b, c) == t(420)
         @test d == t(420)
-        @test MA.muladd_buf!(buf, a, b, c) == t(420)
+        @test MA.add_mul_buf!(buf, a, b, c) == t(420)
         @test a == t(420)
     end
 end
 
 function int_zero_test(::Type{T}) where T
     @testset "zero!" begin
-        @test MA.mutability(T, MA.zero!) isa MA.IsMutable
+        @test MA.mutability(T, zero, T) isa MA.IsMutable
 
         t(n) = convert(T, n)
         a = t(5)
@@ -94,7 +91,7 @@ end
 
 function int_one_test(::Type{T}) where T
     @testset "one!" begin
-        @test MA.mutability(T, MA.one!) isa MA.IsMutable
+        @test MA.mutability(T, one, T) isa MA.IsMutable
 
         t(n) = convert(T, n)
         a = t(5)
@@ -107,7 +104,7 @@ end
 const int_tests = Dict(
     "int_add" => int_add_test,
     "int_mul" => int_mul_test,
-    "int_muladd" => int_muladd_test,
+    "int_add_mul" => int_add_mul_test,
     "int_zero" => int_zero_test,
     "int_one" => int_one_test
 )

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -33,7 +33,7 @@ mutability(x, op, args...) = mutability(typeof(x), op, typeof.(args)...)
 mutability(::Type) = NotMutable()
 
 function mutable_operate_to_fallback(::NotMutable, output, op::Function, args...)
-    throw(ArgumentError("Cannot call `mutable_operate_to!($output, $op, $(args...))` as `$output` cannot be modifed to equal the result of the operation. Use `operate!` or `operate_to!` instead which returns the value of he result (possibly modifying the first argument) to write generic code that also works when the type cannot be modified."))
+    throw(ArgumentError("Cannot call `mutable_operate_to!($output, $op, $(args...))` as `$output` cannot be modifed to equal the result of the operation. Use `operate!` or `operate_to!` instead which returns the value of the result (possibly modifying the first argument) to write generic code that also works when the type cannot be modified."))
 end
 
 function mutable_operate_to_fallback(::IsMutable, op::Function, args...)

--- a/src/shortcuts.jl
+++ b/src/shortcuts.jl
@@ -75,7 +75,7 @@ end
 
 Return `zero(a)`, possibly modifying `a`.
 """
-zero!(x) = operate!(zero, x)
+zero!(a) = operate!(zero, a)
 
 """
     one!(a)

--- a/src/shortcuts.jl
+++ b/src/shortcuts.jl
@@ -82,4 +82,4 @@ zero!(a) = operate!(zero, a)
 
 Return `one(a)`, possibly modifying `a`.
 """
-one!(x) = operate!(one, x)
+one!(a) = operate!(one, a)

--- a/src/shortcuts.jl
+++ b/src/shortcuts.jl
@@ -29,7 +29,7 @@ mul!(args...) = operate!(*, args...)
 """
     add_mul(a, args...)
 
-Return `a + *(args...)`. Note that `add_mul(a, b, c) = addmul(b, c, a)`.
+Return `a + *(args...)`. Note that `add_mul(a, b, c) = muladd(b, c, a)`.
 """
 function add_mul end
 add_mul(a, b, c) = muladd(b, c, a)

--- a/src/shortcuts.jl
+++ b/src/shortcuts.jl
@@ -1,0 +1,85 @@
+"""
+    add_to!(a, b, c)
+
+Return the sum of `b` and `c`, possibly modifying `a`.
+"""
+add_to!(output, args...) = operate_to!(output, +, args...)
+
+"""
+    add!(a, b, ...)
+
+Return the sum of `a`, `b`, ..., possibly modifying `a`.
+"""
+add!(args...) = operate!(+, args...)
+
+"""
+    mul_to!(a, b, c)
+
+Return the product of `b` and `c`, possibly modifying `a`.
+"""
+mul_to!(output, args...) = operate_to!(output, *, args...)
+
+"""
+    mul!(a, b, ...)
+
+Return the product of `a`, `b`, ..., possibly modifying `a`.
+"""
+mul!(args...) = operate!(*, args...)
+
+"""
+    add_mul(a, args...)
+
+Return `a + *(args...)`. Note that `add_mul(a, b, c) = addmul(b, c, a)`.
+"""
+function add_mul end
+add_mul(a, b, c) = muladd(b, c, a)
+
+function promote_operation(::typeof(add_mul), T::Type, args::Type...)
+    return promote_operation(+, T, promote_operation(*, args...))
+end
+
+"""
+    add_mul_to!(output, args...)
+
+Return `add_mul(args...)`, possibly modifying `output`.
+"""
+add_mul_to!(output, args...) = operate_to!(output, add_mul, args...)
+
+"""
+    add_mul!(args...)
+
+Return `add_mul(args...)`, possibly modifying `args[1]`.
+"""
+add_mul!(args...) = operate!(add_mul, args...)
+
+"""
+    add_mul_buf_to!(buffer, output, args...)
+
+Return `add_mul(args...)`, possibly modifying `output` and `buffer`.
+"""
+function add_mul_buf_to!(buffer, output, args...)
+    buffered_operate_to!(buffer, output, add_mul, args...)
+end
+
+"""
+    add_mul_buf!(buffer, args...)
+
+Return `add_mul(args...)`, possibly modifying `args[1]` and `buffer`.
+"""
+function add_mul_buf!(buffer, args...)
+    buffered_operate!(buffer, add_mul, args...)
+end
+
+"""
+    zero!(a)
+
+Return `zero(a)`, possibly modifying `a`.
+"""
+zero!(x) = operate!(zero, x)
+
+"""
+    one!(a)
+
+Return `one(a)`, possibly modifying `a`.
+"""
+one!(x) = operate!(one, x)

--- a/test/int.jl
+++ b/test/int.jl
@@ -24,35 +24,35 @@ end
     @test MA.mul!(a, b) == 420
 end
 
-@testset "muladd_to! / muladd! / muladd_buf_to! /muladd_buf!" begin
-    @test MA.mutability(Int, MA.muladd_to!, Int, Int, Int) isa MA.NotMutable
-    @test MA.mutability(Int, MA.muladd!, Int, Int) isa MA.NotMutable
-    @test MA.mutability(Int, MA.muladd_buf_to!, Int, Int, Int, Int) isa MA.NotMutable
-    @test MA.mutability(Int, MA.muladd_buf!, Int, Int, Int) isa MA.NotMutable
+@testset "add_mul_to! / add_mul! / add_mul_buf_to! /add_mul_buf!" begin
+    @test MA.mutability(Int, MA.add_mul_to!, Int, Int, Int) isa MA.NotMutable
+    @test MA.mutability(Int, MA.add_mul!, Int, Int) isa MA.NotMutable
+    @test MA.mutability(Int, MA.add_mul_buf_to!, Int, Int, Int, Int) isa MA.NotMutable
+    @test MA.mutability(Int, MA.add_mul_buf!, Int, Int, Int) isa MA.NotMutable
     a = 5
     b = 9
     c = 3
     d = 20
     buf = 24
-    @test MA.muladd_to!(a, b, c, d) == 69
-    @test MA.muladd!(b, c, d) == 69
-    @test MA.muladd_buf_to!(buf, a, b, c, d) == 69
-    @test MA.muladd_buf!(buf, b, c, d) == 69
+    @test MA.add_mul_to!(a, b, c, d) == 69
+    @test MA.add_mul!(b, c, d) == 69
+    @test MA.add_mul_buf_to!(buf, a, b, c, d) == 69
+    @test MA.add_mul_buf!(buf, b, c, d) == 69
     a = 148
     b = 16
     c = 17
-    @test MA.muladd!(a, b, c) == 420
+    @test MA.add_mul!(a, b, c) == 420
     a = 148
     b = 16
     c = 17
     buf = 56
-    @test MA.muladd_buf!(buf, a, b, c) == 420
+    @test MA.add_mul_buf!(buf, a, b, c) == 420
     a = 148
     b = 16
     c = 17
     d = 42
     buf = 56
-    @test MA.muladd_buf_to!(buf, d, a, b, c) == 420
+    @test MA.add_mul_buf_to!(buf, d, a, b, c) == 420
 end
 
 @testset "zero!" begin

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -7,19 +7,11 @@
 		@test MA.mul(A, x) == BigInt[3; 3; 3]
 		@test MA.mul_to!(y, A, x) == BigInt[3; 3; 3] && y == BigInt[3; 3; 3]
 
-		MA.mutability(::Type{BigInt}, ::typeof(MA.zero!)) = MA.IsMutable()
-		MA.zero_impl!(x::BigInt) = Base.GMP.MPZ.set_si!(x, 0)
-		MA.mutability(::Type{BigInt}, ::typeof(MA.mul_to!), ::Type{BigInt}, ::Type{BigInt}) = MA.IsMutable()
-		MA.mul_to_impl!(x::BigInt, a::BigInt, b::BigInt) = Base.GMP.MPZ.mul!(x, a, b)
-		MA.mutability(::Type{BigInt}, ::typeof(MA.add_to!), ::Type{BigInt}, ::Type{BigInt}) = MA.IsMutable()
-		MA.add_to_impl!(x::BigInt, a::BigInt, b::BigInt) = Base.GMP.MPZ.add!(x, a, b)
-		MA.muladd_buf_impl!(buf::BigInt, a::BigInt, b::BigInt, c::BigInt) = Base.GMP.MPZ.add!(a, Base.GMP.MPZ.mul!(buf, b, c))
-
 		A = BigInt[1 1 1; 1 1 1; 1 1 1]
 		x = BigInt[1; 1; 1]
 		y = BigInt[0; 0; 0]
 
-		@test MA.mutability(y, MA.mul_to!, A, x) isa MA.IsMutable
+		@test MA.mutability(y, *, A, x) isa MA.IsMutable
 		@test MA.mul(A, x) == BigInt[3; 3; 3]
 		@test MA.mul_to!(y, A, x) == BigInt[3; 3; 3] && y == BigInt[3; 3; 3]
 		@test_throws DimensionMismatch MA.mul(BigInt[1 1; 1 1], BigInt[])


### PR DESCRIPTION
This enforces a consistent behaviors between `add!`, `add_to!` and `mul!`, `mul_to!`, ...