### PR TITLE
Mutable array operations

### DIFF
--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -13,15 +13,15 @@ uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
 
 [[DocStringExtensions]]
 deps = ["LibGit2", "Markdown", "Pkg", "Test"]
-git-tree-sha1 = "0513f1a8991e9d83255e0140aace0d0fc4486600"
+git-tree-sha1 = "88bb0edb352b16608036faadcc071adda068582a"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
-version = "0.8.0"
+version = "0.8.1"
 
 [[Documenter]]
-deps = ["Base64", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
-git-tree-sha1 = "4a84478277020abfff208cde31ba1aa68a5bc572"
+deps = ["Base64", "Dates", "DocStringExtensions", "InteractiveUtils", "JSON", "LibGit2", "Logging", "Markdown", "REPL", "Test", "Unicode"]
+git-tree-sha1 = "0be9bf63e854a2408c2ecd3c600d68d4d87d8a73"
 uuid = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-version = "0.23.0"
+version = "0.24.2"
 
 [[InteractiveUtils]]
 deps = ["Markdown"]
@@ -48,9 +48,9 @@ uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[Parsers]]
 deps = ["Dates", "Test"]
-git-tree-sha1 = "db2b35dedab3c0e46dc15996d170af07a5ab91c9"
+git-tree-sha1 = "0139ba59ce9bc680e2925aec5b7db79065d60556"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "0.3.6"
+version = "0.3.10"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,3 +1,10 @@
+```@meta
+CurrentModule = MutableArithmetics
+DocTestSetup = quote
+    using MutableArithmetics
+end
+```
+
 # MutableArithmetics.jl
 
 ```@index

--- a/src/MutableArithmetics.jl
+++ b/src/MutableArithmetics.jl
@@ -32,10 +32,7 @@ include("Test/Test.jl")
 # Implementation of the interface for Base types
 import LinearAlgebra
 const Scaling = Union{Number, LinearAlgebra.UniformScaling}
-#mutable_copy(A::LinearAlgebra.Symmetric) = LinearAlgebra.Symmetric(mutable_copy(parent(A)), ifelse(A.uplo == 'U', :U, :L))
-## Broadcast applies the transpose
-#mutable_copy(A::LinearAlgebra.Transpose) = LinearAlgebra.Transpose(mutable_copy(parent(A)))
-#mutable_copy(A::LinearAlgebra.Adjoint) = LinearAlgebra.Adjoint(mutable_copy(parent(A)))
+scaling(x::Scaling) = x
 include("bigint.jl")
 include("linear_algebra.jl")
 
@@ -43,8 +40,8 @@ isequal_canonical(a, b) = a == b
 
 include("rewrite.jl")
 
-include("dispatch.jl")
-
 include("sparse_arrays.jl")
+
+include("dispatch.jl")
 
 end # module

--- a/src/bigint.jl
+++ b/src/bigint.jl
@@ -31,6 +31,7 @@ function mutable_operate_to!(output::BigInt, op::Union{typeof(*), typeof(+)},
 end
 
 # add_mul
+buffer_for(::typeof(add_mul), args::Vararg{Type{BigInt}, N}) where {N} = BigInt()
 function mutable_operate_to!(output::BigInt, ::typeof(add_mul), args::Vararg{BigInt, N}) where N
     return mutable_buffered_operate_to!(BigInt(), output, add_mul, args...)
 end
@@ -43,6 +44,6 @@ end
 scaling_to_bigint(x::BigInt) = x
 scaling_to_bigint(x::Number) = convert(BigInt, x)
 scaling_to_bigint(J::LinearAlgebra.UniformScaling) = scaling_to_bigint(J.λ)
-function mutable_operate_to!(output::BigInt, op::Function, args::Vararg{Scaling, N}) where N
+function mutable_operate_to!(output::BigInt, op::Union{typeof(+), typeof(*), typeof(add_mul)}, args::Vararg{Scaling, N}) where N
     return mutable_operate_to!(output, op, scaling_to_bigint.(args)...)
 end

--- a/src/dispatch.jl
+++ b/src/dispatch.jl
@@ -1,4 +1,39 @@
+# TODO: Intercepting "externally owned" method calls by dispatching on type parameters
+# (rather than outermost wrapper type) is generally bad practice, but refactoring this code
+# to use a different mechanism would be a lot of work. In the future, this interception code
+# would be more easily/robustly replaced by using a tool like
+# https://github.com/jrevels/Cassette.jl.
+
 abstract type AbstractMutable end
+
+function Base.sum(a::AbstractArray{<:AbstractMutable})
+    return mapreduce(identity, add!, a, init = zero(promote_operation(+, eltype(a), eltype(a))))
+end
+
+LinearAlgebra.dot(lhs::AbstractArray{<:AbstractMutable}, rhs::AbstractArray) = _dot(lhs, rhs)
+LinearAlgebra.dot(lhs::AbstractArray, rhs::AbstractArray{<:AbstractMutable}) = _dot(lhs, rhs)
+LinearAlgebra.dot(lhs::AbstractArray{<:AbstractMutable}, rhs::AbstractArray{<:AbstractMutable}) = _dot(lhs, rhs)
+
+function _dot(x::AbstractArray, y::AbstractArray)
+    lx = length(x)
+    if lx != length(y)
+        throw(DimensionMismatch("first array has length $(lx) which does not match the length of the second, $(length(y))."))
+    end
+    if iszero(lx)
+        return LinearAlgebra.dot(zero(eltype(x)), zero(eltype(y)))
+    end
+
+    # We need a buffer to hold the intermediate multiplication.
+    mul_buffer = buffer_for(add_mul, eltype(x), eltype(y))
+
+    s = zero(promote_operation(add_mul, eltype(x), eltype(x), eltype(y)))
+
+    for (Ix, Iy) in zip(eachindex(x), eachindex(y))
+        s = @inbounds buffered_operate!(mul_buffer, add_mul, s, x[Ix], y[Iy])
+    end
+
+    return s
+end
 
 # Special-case because the the base version wants to do fill!(::Array{AbstractVariableRef}, zero(GenericAffExpr{Float64,eltype(x)}))
 _one_indexed(A) = all(x -> isa(x, Base.OneTo), axes(A))
@@ -6,4 +41,144 @@ function LinearAlgebra.diagm(x::AbstractVector{<:AbstractMutable})
     @assert _one_indexed(x) # `LinearAlgebra.diagm` doesn't work for non-one-indexed arrays in general.
     ZeroType = promote_operation(zero, eltype(x))
     return LinearAlgebra.diagm(0 => copyto!(similar(x, ZeroType), x))
+end
+
+###############################################################################
+# Interception of Base's matrix/vector arithmetic machinery
+
+# Redirect calls with `eltype(ret) <: AbstractMutable` to `_mul!` to
+# replace it with an implementation more efficient than `generic_matmatmul!` and
+# `generic_matvecmul!` since it takes into account the mutability of the arithmetic.
+# We need `args...` because SparseArrays` also gives `α` and `β` arguments.
+
+function _mul!(output, A, B, α, β)
+    # See SparseArrays/src/linalg.jl
+    if !isone(β)
+        if iszero(β)
+            mutable_operate!(zero, output)
+        else
+            rmul!(output, β)
+        end
+    end
+    return mutable_operate!(add_mul, output, A, B, α)
+end
+function _mul!(output, A, B, α)
+    mutable_operate!(zero, output)
+    return mutable_operate!(add_mul, output, A, B, α)
+end
+function _mul!(output, A, B)
+    mutable_operate!(zero, output)
+    return mutable_operate!(add_mul, output, A, B)
+end
+
+function LinearAlgebra.mul!(ret::AbstractMatrix{<:AbstractMutable},
+                            A::AbstractVecOrMat, B::AbstractVecOrMat, args::Vararg{Any, N}) where N
+    _mul!(ret, A, B, args...)
+end
+function LinearAlgebra.mul!(ret::AbstractVector{<:AbstractMutable},
+                            A::AbstractVecOrMat, B::AbstractVector, args...)
+    _mul!(ret, A, B, args...)
+end
+function LinearAlgebra.mul!(ret::AbstractVector{<:AbstractMutable},
+                            A::LinearAlgebra.Transpose{<:Any,<:AbstractVecOrMat},
+                            B::AbstractVector, args...)
+    _mul!(ret, A, B, args...)
+end
+function LinearAlgebra.mul!(ret::AbstractVector{<:AbstractMutable},
+                            A::LinearAlgebra.Adjoint{<:Any,<:AbstractVecOrMat},
+                            B::AbstractVector, args...)
+    _mul!(ret, A, B, args...)
+end
+function LinearAlgebra.mul!(ret::AbstractMatrix{<:AbstractMutable},
+                            A::LinearAlgebra.Transpose{<:Any,<:AbstractVecOrMat},
+                            B::AbstractMatrix, args...)
+    _mul!(ret, A, B, args...)
+end
+function LinearAlgebra.mul!(ret::AbstractMatrix{<:AbstractMutable},
+                            A::LinearAlgebra.Adjoint{<:Any,<:AbstractVecOrMat},
+                            B::AbstractMatrix, args...)
+    _mul!(ret, A, B, args...)
+end
+function LinearAlgebra.mul!(ret::AbstractMatrix{<:AbstractMutable},
+                            A::AbstractMatrix,
+                            B::LinearAlgebra.Transpose{<:Any,<:AbstractVecOrMat}, args...)
+    _mul!(ret, A, B, args...)
+end
+function LinearAlgebra.mul!(ret::AbstractMatrix{<:AbstractMutable},
+                            A::AbstractMatrix,
+                            B::LinearAlgebra.Adjoint{<:Any,<:AbstractVecOrMat}, args...)
+    _mul!(ret, A, B, args...)
+end
+
+# SparseArrays promotes the element types of `A` and `B` to the same type
+# which always produce quadratic expressions for JuMP even if only one of them
+# was affine and the other one constant. Moreover, it does not always go through
+# `LinearAlgebra.mul!` which prevents us from using mutability of the arithmetic.
+# For this reason we intercept the calls and redirect them to `mul`.
+
+# A few are overwritten below but many more need to be redirected to `mul` in
+# `linalg.jl`.
+
+Base.:*(A::SparseMat{<:AbstractMutable}, x::StridedVector) = mul(A, x)
+Base.:*(A::SparseMat, x::StridedVector{<:AbstractMutable}) = mul(A, x)
+Base.:*(A::SparseMat{<:AbstractMutable}, x::StridedVector{<:AbstractMutable}) = mul(A, x)
+
+Base.:*(A::SparseMat{<:AbstractMutable}, B::SparseMat{<:AbstractMutable}) = mul(A, B)
+Base.:*(A::SparseMat{<:Any}, B::SparseMat{<:AbstractMutable}) = mul(A, B)
+Base.:*(A::SparseMat{<:AbstractMutable}, B::SparseMat{<:Any}) = mul(A, B)
+
+Base.:*(A::SparseMat{<:AbstractMutable}, B::LinearAlgebra.Adjoint{<:AbstractMutable, <:SparseMat}) = mul(A, B)
+Base.:*(A::SparseMat{<:Any}, B::LinearAlgebra.Adjoint{<:AbstractMutable, <:SparseMat}) = mul(A, B)
+Base.:*(A::SparseMat{<:AbstractMutable}, B::LinearAlgebra.Adjoint{<:Any, <:SparseMat}) = mul(A, B)
+
+Base.:*(A::LinearAlgebra.Adjoint{<:AbstractMutable, <:SparseMat}, B::SparseMat{<:AbstractMutable}) = mul(A, B)
+Base.:*(A::LinearAlgebra.Adjoint{<:Any, <:SparseMat}, B::SparseMat{<:AbstractMutable}) = mul(A, B)
+Base.:*(A::LinearAlgebra.Adjoint{<:AbstractMutable, <:SparseMat}, B::SparseMat{<:Any}) = mul(A, B)
+
+Base.:*(A::StridedMatrix{<:AbstractMutable}, B::SparseMat{<:AbstractMutable}) = mul(A, B)
+Base.:*(A::StridedMatrix{<:Any}, B::SparseMat{<:AbstractMutable}) = mul(A, B)
+Base.:*(A::StridedMatrix{<:AbstractMutable}, B::SparseMat{<:Any}) = mul(A, B)
+
+Base.:*(A::SparseMat{<:AbstractMutable}, B::StridedMatrix{<:AbstractMutable}) = mul(A, B)
+Base.:*(A::SparseMat{<:Any}, B::StridedMatrix{<:AbstractMutable}) = mul(A, B)
+Base.:*(A::SparseMat{<:AbstractMutable}, B::StridedMatrix{<:Any}) = mul(A, B)
+
+Base.:*(A::LinearAlgebra.Adjoint{<:AbstractMutable, <:SparseMat}, B::StridedMatrix{<:AbstractMutable}) = mul(A, B)
+Base.:*(A::LinearAlgebra.Adjoint{<:Any, <:SparseMat}, B::StridedMatrix{<:AbstractMutable}) = mul(A, B)
+Base.:*(A::LinearAlgebra.Adjoint{<:AbstractMutable, <:SparseMat}, B::StridedMatrix{<:Any}) = mul(A, B)
+
+# Base doesn't define efficient fallbacks for sparse array arithmetic involving
+# non-`<:Number` scalar elements, so we define some of these for `<:AbstractMutable` scalar
+# elements here.
+
+function Base.:*(A::Scaling, B::SparseMat{<:AbstractMutable})
+    return SparseMat(B.m, B.n, copy(B.colptr), copy(rowvals(B)), A .* nonzeros(B))
+end
+
+function Base.:*(A::SparseMat{<:AbstractMutable}, B::Scaling)
+    return SparseMat(A.m, A.n, copy(A.colptr), copy(rowvals(A)), nonzeros(A) .* B)
+end
+
+function Base.:*(A::AbstractMutable, B::SparseMat)
+    return SparseMat(B.m, B.n, copy(B.colptr), copy(rowvals(B)), A .* nonzeros(B))
+end
+
+function Base.:*(A::SparseMat, B::AbstractMutable)
+    return SparseMat(A.m, A.n, copy(A.colptr), copy(rowvals(A)), nonzeros(A) .* B)
+end
+
+function Base.:/(A::SparseMat{<:AbstractMutable}, B::Scaling)
+    return SparseMat(A.m, A.n, copy(A.colptr), copy(rowvals(A)), nonzeros(A) ./ B)
+end
+
+Base.:+(A::AbstractArray{<:AbstractMutable}) = A
+
+# Fix https://github.com/JuliaLang/julia/issues/32374 as done in
+# https://github.com/JuliaLang/julia/pull/32375. This hack should
+# be removed once we drop Julia v1.0.
+function Base.:-(A::LinearAlgebra.Symmetric{<:AbstractMutable})
+    return LinearAlgebra.Symmetric(-parent(A), LinearAlgebra.sym_uplo(A.uplo))
+end
+function Base.:-(A::LinearAlgebra.Hermitian{<:AbstractMutable})
+    return LinearAlgebra.Hermitian(-parent(A), LinearAlgebra.sym_uplo(A.uplo))
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -84,6 +84,8 @@ function mutable_operate!(op::Function, args::Vararg{Any, N}) where N
     mutable_operate_to!(args[1], op, args...)
 end
 
+buffer_for(::Function, args::Vararg{Type, N}) where {N} = nothing
+
 """
     mutable_buffered_operate_to!(buffer, output, op::Function, args...)
 
@@ -91,7 +93,9 @@ Modify the value of `output` to be equal to the value of `op(args...)`,
 possibly modifying `buffer`. Can only be called if
 `mutability(output, op, args...)` returns `true`.
 """
-function mutable_buffered_operate_to! end
+function mutable_buffered_operate_to!(::Nothing, output, op::Function, args::Vararg{Any, N}) where N
+    return mutable_operate_to!(output, op, args...)
+end
 
 """
     mutable_buffered_operate!(buffer, op::Function, args...)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -107,6 +107,9 @@ possibly modifying `buffer`. Can only be called if
 function mutable_buffered_operate!(buffer, op::Function, args::Vararg{Any, N}) where N
     mutable_buffered_operate_to!(buffer, args[1], op, args...)
 end
+function mutable_buffered_operate!(::Nothing, op::Function, args::Vararg{Any, N}) where N
+    return mutable_operate!(op, args...)
+end
 
 """
     operate_to!(output, op::Function, args...)

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -47,7 +47,7 @@ function mutable_operate!(::typeof(add_mul), A::Array{S, N}, α1::Scaling, α2::
 end
 # Fallback, we may be able to be more efficient in more cases by adding more specialized methods
 function mutable_operate!(::typeof(add_mul), A::Array, x, y, args::Vararg{Any, N}) where N
-    return mutable_operate!(+, A, *(x, y, args...))
+    return mutable_operate!(add_mul, A, x, *(y, args...))
 end
 
 # Product
@@ -67,50 +67,160 @@ end
 function promote_array_mul(::Type{Matrix{S}}, ::Type{Vector{T}}) where {S, T}
     return Vector{Base.promote_op(LinearAlgebra.matprod, S, T)}
 end
+function promote_array_mul(::Type{<:AbstractMatrix{S}}, ::Type{<:AbstractMatrix{T}}) where {S, T}
+    return Matrix{Base.promote_op(LinearAlgebra.matprod, S, T)}
+end
 function promote_array_mul(::Type{<:AbstractMatrix{S}}, ::Type{<:AbstractVector{T}}) where {S, T}
     return Vector{Base.promote_op(LinearAlgebra.matprod, S, T)}
 end
-function mutable_operate_to!(C::Vector, ::typeof(*), A::AbstractMatrix, B::AbstractVector)
+
+################################################################################
+# We roll our own matmul here (instead of using Julia's generic fallbacks)
+# because doing so allows us to accumulate the expressions for the inner loops
+# in-place.
+# Additionally, Julia's generic fallbacks can be finnicky when your array
+# elements aren't `<:Number`.
+
+# This method of `mul!` is adapted from upstream Julia. Note that we
+# confuse transpose with adjoint.
+#=
+> Copyright (c) 2009-2018: Jeff Bezanson, Stefan Karpinski, Viral B. Shah,
+> and other contributors:
+>
+> https://github.com/JuliaLang/julia/contributors
+>
+> Permission is hereby granted, free of charge, to any person obtaining
+> a copy of this software and associated documentation files (the
+> "Software"), to deal in the Software without restriction, including
+> without limitation the rights to use, copy, modify, merge, publish,
+> distribute, sublicense, and/or sell copies of the Software, and to
+> permit persons to whom the Software is furnished to do so, subject to
+> the following conditions:
+>
+> The above copyright notice and this permission notice shall be
+> included in all copies or substantial portions of the Software.
+>
+> THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+> EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+> MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+> NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+> LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+> OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+> WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+=#
+
+function _mut_check(C, A, B)
     if mutability(eltype(C), add_mul, eltype(C), eltype(A), eltype(B)) isa NotMutable
-        return LinearAlgebra.mul!(C, A, B)
+        error("mutable_operate!(add_mul, ::$(typeof(C)), ::$(typeof(A)), ::$(typeof(B))) not implemented as $(eltype(C)) cannot be mutated to the result.")
     end
-    # If `mutability(S, muladd!, T, U)` is `NotMutable`, we might as well redirect to `LinearAlgebra.mul!(C, A, B)`
-    # in which case we can do `muladd_buf_impl!(mul_buffer, A[aoffs + i], b, C[i])` here instead of
-    # `A[aoffs + i] = muladd_buf!(mul_buffer, A[aoffs + i], b, C[i])`
+end
+
+function _dim_check(C::AbstractVector, A::AbstractMatrix, B::AbstractVector)
+    _mut_check(C, A, B)
+
     mB = length(B)
-    mA, nA = (size(A, 1), size(A, 2)) # lapack_size is not exposed.
+    mA, nA = size(A)
     if mB != nA
         throw(DimensionMismatch("matrix A has dimensions ($mA,$nA), vector B has length $mB"))
     end
     if mA != length(C)
         throw(DimensionMismatch("result C has length $(length(C)), needs length $mA"))
     end
+end
 
+function _dim_check(C::AbstractMatrix, A::AbstractMatrix, B::AbstractMatrix)
+    _mut_check(C, A, B)
+
+    mB, nB = size(B)
+    mA, nA = size(A)
+    if mB != nA
+        throw(DimensionMismatch("matrix A has dimensions ($mA,$nA), matrix B has dimensions ($mB,$nB)"))
+    end
+    if size(C, 1) != mA || size(C, 2) != nB
+        throw(DimensionMismatch("result C has dimensions $(size(C)), needs ($mA,$nB)"))
+    end
+end
+
+function _add_mul_array(C::Vector, A::AbstractMatrix, B::AbstractVector)
     Astride = size(A, 1)
-    @inbounds begin
-        for i = 1:mA
-            C[i] = zero!(C[i])
-        end
+    # We need a buffer to hold the intermediate multiplication.
+    mul_buffer = buffer_for(add_mul, eltype(A), eltype(B))
 
-        # We need a buffer to hold the intermediate multiplication.
-        mul_buffer = zero(promote_operation(*, eltype(A), eltype(B)))
-        for k = Base.OneTo(mB)
+    #@inbounds begin
+        for k = eachindex(B)
             aoffs = (k-1) * Astride
             b = B[k]
-            for i = Base.OneTo(mA)
+            for i = Base.OneTo(size(A, 1))
                 mutable_buffered_operate!(mul_buffer, add_mul, C[i], A[aoffs + i], b)
             end
         end
-    end # @inbounds
+    #end # @inbounds
+
     return C
 end
 
+# This is incorrect if `C` is `LinearAlgebra.Symmetric` as we modify twice the same diagonal element.
+function _add_mul_array(C::Matrix, A::AbstractMatrix, B::AbstractMatrix)
+    mul_buffer = buffer_for(add_mul, eltype(A), eltype(B))
+
+    #@inbounds begin
+        for i = 1:size(A, 1), j = 1:size(B, 2)
+            Ctmp = C[i, j]
+            mutable_operate!(zero, Ctmp)
+            for k = 1:size(A, 2)
+                mutable_buffered_operate!(mul_buffer, add_mul, Ctmp, A[i, k], B[k, j])
+            end
+        end
+    #end # @inbounds
+
+    return C
+end
+
+function mutable_operate!(::typeof(add_mul), C::VecOrMat, A::AbstractMatrix, B::AbstractVecOrMat)
+    _dim_check(C, A, B)
+    _add_mul_array(C, A, B)
+end
+
+function mutable_operate!(::typeof(zero), C::Union{Vector, Matrix})
+    # C may contain undefined values so we cannot call `zero!`
+    for i in eachindex(C)
+        #@inbounds C[i] = zero(eltype(C))
+        C[i] = zero(eltype(C))
+    end
+end
+
+function mutable_operate_to!(C::Union{Vector, Matrix}, ::typeof(*), A::AbstractMatrix, B::AbstractVecOrMat)
+    # If `mutability(S, muladd!, T, U)` is `NotMutable`, we might as well redirect to `LinearAlgebra.mul!(C, A, B)`
+    # in which case we can do `muladd_buf_impl!(mul_buffer, A[aoffs + i], b, C[i])` here instead of
+    # `A[aoffs + i] = muladd_buf!(mul_buffer, A[aoffs + i], b, C[i])`
+    if mutability(eltype(C), add_mul, eltype(C), eltype(A), eltype(B)) isa NotMutable
+        return LinearAlgebra.mul!(C, A, B)
+    end
+
+    mutable_operate!(zero, C)
+    return mutable_operate!(add_mul, C, A, B)
+end
+
+# `mul` does what `LinearAlgebra/src/matmul.jl` does for abstract
+# matrices and vector, i.e., use `matprod` to estimate the resulting element
+# type, allocate the resulting array but it redirects to `mul_to!` instead of
+# `LinearAlgebra.mul!`.
 function mul(A::AbstractMatrix{S}, B::AbstractVector{T}) where {T, S}
     U = Base.promote_op(LinearAlgebra.matprod, S, T)
-    C = similar(B, U, axes(A, 1))
-    # C now contains only undefined values, we need to fill this with actual zeros
-    for i in eachindex(C)
-        @inbounds C[i] = zero(U)
-    end
-    return mul_to!(C, A, B)
+    # `similar` gives SparseMatrixCSC if `B` is SparseMatrixCSC
+    #C = similar(B, U, axes(A, 1))
+    C = Vector{U}(undef, size(A, 1))
+    return mutable_operate_to!(C, *, A, B)
 end
+function mul(A::AbstractMatrix{S}, B::AbstractMatrix{T}) where {T, S}
+    U = Base.promote_op(LinearAlgebra.matprod, S, T)
+    # `similar` gives SparseMatrixCSC if `B` is SparseMatrixCSC
+    #C = similar(B, U, axes(A, 1), axes(B, 2))
+    C = Matrix{U}(undef, size(A, 1), size(B, 2))
+    return mutable_operate_to!(C, *, A, B)
+end
+
+#mutable_copy(A::LinearAlgebra.Symmetric) = LinearAlgebra.Symmetric(mutable_copy(parent(A)), LinearAlgebra.sym_uplo(A.uplo))
+# Broadcast applies the transpose
+#mutable_copy(A::LinearAlgebra.Transpose) = LinearAlgebra.Transpose(mutable_copy(parent(A)))
+#mutable_copy(A::LinearAlgebra.Adjoint) = LinearAlgebra.Adjoint(mutable_copy(parent(A)))

--- a/src/rewrite.jl
+++ b/src/rewrite.jl
@@ -45,6 +45,8 @@ with nested filters as specified.
 # Examples
 
 ```jldoctest
+julia> using MutableArithmetics
+
 julia> MutableArithmetics.rewrite_generator(:(i for i in 1:2 if isodd(i)), i -> :(\$i + 1))
 :(for \$(Expr(:escape, :(i = 1:2)))
       if \$(Expr(:escape, :(isodd(i))))

--- a/src/shortcuts.jl
+++ b/src/shortcuts.jl
@@ -26,6 +26,10 @@ Return the product of `a`, `b`, ..., possibly modifying `a`.
 """
 mul!(args::Vararg{Any, N}) where {N} = operate!(*, args...)
 
+# `Vararg` gives extra allocations on Julia v1.3, see https://travis-ci.com/JuliaOpt/MutableArithmetics.jl/jobs/260666164#L215-L238
+function promote_operation(::typeof(add_mul), T::Type, x::Type, y::Type)
+    return promote_operation(+, T, promote_operation(*, x, y))
+end
 function promote_operation(::typeof(add_mul), T::Type, args::Vararg{Type, N}) where N
     return promote_operation(+, T, promote_operation(*, args...))
 end

--- a/src/sparse_arrays.jl
+++ b/src/sparse_arrays.jl
@@ -87,6 +87,13 @@ function mutable_operate!(::typeof(add_mul), ret::Matrix{T},
     return ret
 end
 function mutable_operate!(::typeof(add_mul), ret::Matrix{T},
+                          A::SparseMat, B::SparseMat,
+                          α::Vararg{Union{T, Scaling}, N}) where {T, N}
+    # Resolve ambiguity (detected on Julia v1.3) with two methods above.
+    # TODO adapt implementation of `SparseArray.spmatmul`
+    mutable_operate!(add_mul, ret, Matrix(A), B, α...)
+end
+function mutable_operate!(::typeof(add_mul), ret::Matrix{T},
                           A::AbstractMatrix,
                           adjB::TransposeOrAdjoint{<:Any, <:SparseMat},
                           α::Vararg{Union{T, Scaling}, N}) where {T, N}
@@ -104,6 +111,20 @@ function mutable_operate!(::typeof(add_mul), ret::Matrix{T},
         end
     end
     return ret
+end
+function mutable_operate!(::typeof(add_mul), ret::Matrix{T},
+                          A::SparseMat, B::TransposeOrAdjoint{<:Any, <:SparseMat},
+                          α::Vararg{Union{T, Scaling}, N}) where {T, N}
+    # Resolve ambiguity (detected on Julia v1.3) with two methods above.
+    # TODO adapt implementation of `SparseArray.spmatmul`
+    mutable_operate!(add_mul, ret, Matrix(A), B, α...)
+end
+function mutable_operate!(::typeof(add_mul), ret::Matrix{T},
+                          A::TransposeOrAdjoint{<:Any, <:SparseMat}, B::SparseMat,
+                          α::Vararg{Union{T, Scaling}, N}) where {T, N}
+    # Resolve ambiguity (detected on Julia v1.3) with two methods above.
+    # TODO adapt implementation of `SparseArray.spmatmul`
+    mutable_operate!(add_mul, ret, Matrix(A), B, α...)
 end
 
 # TODO

--- a/src/sparse_arrays.jl
+++ b/src/sparse_arrays.jl
@@ -1,3 +1,134 @@
 import SparseArrays
+
+const SparseMat = SparseArrays.SparseMatrixCSC
+
+function mutable_operate!(::typeof(zero), A::SparseMat)
+    for i in eachindex(A.colptr)
+        A.colptr[i] = one(A.colptr[i])
+    end
+    empty!(A.rowval)
+    empty!(A.nzval)
+    return A
+end
+
 similar_array_type(::Type{SparseArrays.SparseVector{Tv, Ti}}, ::Type{T}) where {T, Tv, Ti} = SparseArrays.SparseVector{T, Ti}
-similar_array_type(::Type{SparseArrays.SparseMatrixCSC{Tv, Ti}}, ::Type{T}) where {T, Tv, Ti} = SparseArrays.SparseMatrixCSC{T, Ti}
+similar_array_type(::Type{SparseMat{Tv, Ti}}, ::Type{T}) where {T, Tv, Ti} = SparseMat{T, Ti}
+
+const TransposeOrAdjoint{T, MT} = Union{LinearAlgebra.Transpose{T, MT}, LinearAlgebra.Adjoint{T, MT}}
+_mirror_transpose_or_adjoint(x, ::LinearAlgebra.Transpose) = LinearAlgebra.transpose(x)
+_mirror_transpose_or_adjoint(x, ::LinearAlgebra.Adjoint) = LinearAlgebra.adjoint(x)
+
+# `SparseArrays/src/linalg.jl` sometimes create a sparse matrix to contain the result.
+# For instance with `Matrix * Adjoint{SparseMatrixCSC}` and then uses `generic_matmatmul!`
+# which looks quite inefficient as it does not exploit the sparsity of the result matrix and the rhs.
+# The approach used here should be more efficient as we redirect to a method that exploits the sparsity of the rhs and `copyto!` should be faster to write the result matrix.
+function mutable_operate!(::typeof(add_mul), output::SparseMat{T},
+                          A::AbstractMatrix, B::AbstractMatrix) where T
+    C = Matrix{T}(undef, size(output)...)
+    mutable_operate!(zero, C)
+    mutable_operate!(add_mul, C, A, B)
+    copyto!(output, C)
+    return output
+end
+
+function mutable_operate!(::typeof(add_mul), ret::VecOrMat{T},
+                          adjA::TransposeOrAdjoint{<:Any, <:SparseMat},
+                          B::AbstractVecOrMat,
+                          α::Vararg{Union{T, Scaling}, N}) where {T, N}
+    _dim_check(ret, adjA, B)
+    λ = scaling.(α)
+    A = parent(adjA)
+    A_nonzeros = SparseArrays.nonzeros(A)
+    A_rowvals = SparseArrays.rowvals(A)
+    for k ∈ 1:size(ret, 2)
+        for col ∈ 1:A.n
+            cur = ret[col, k]
+            # TODO replace by nzrange
+            for j ∈ A.colptr[col]:(A.colptr[col + 1] - 1)
+                A_val = _mirror_transpose_or_adjoint(A_nonzeros[j], adjA)
+                mutable_operate!(add_mul, cur, A_val, B[A_rowvals[j], k], λ...)
+            end
+        end
+    end
+    return ret
+end
+function mutable_operate!(::typeof(add_mul), ret::VecOrMat{T},
+                          A::SparseMat, B::AbstractVecOrMat,
+                          α::Vararg{Union{T, Scaling}, N}) where {T, N}
+    _dim_check(ret, A, B)
+    λ = scaling.(α)
+    A_nonzeros = SparseArrays.nonzeros(A)
+    A_rowvals = SparseArrays.rowvals(A)
+    for col ∈ 1:size(A, 2)
+        for k ∈ 1:size(ret, 2)
+            αxj = *(B[col,k], λ...)
+            for j ∈ SparseArrays.nzrange(A, col)
+                mutable_operate!(add_mul, ret[A_rowvals[j], k], A_nonzeros[j], αxj)
+            end
+        end
+    end
+    return ret
+end
+function mutable_operate!(::typeof(add_mul), ret::Matrix{T},
+                          A::AbstractMatrix, B::SparseMat,
+                          α::Vararg{Union{T, Scaling}, N}) where {T, N}
+    _dim_check(ret, A, B)
+    λ = scaling.(α)
+    rowval = SparseArrays.rowvals(B)
+    B_nonzeros = SparseArrays.nonzeros(B)
+    for multivec_row in 1:size(A, 1)
+        for col ∈ 1:size(B, 2)
+            cur = ret[multivec_row, col]
+            for k ∈ SparseArrays.nzrange(B, col)
+                mutable_operate!(add_mul, cur, A[multivec_row, rowval[k]], B_nonzeros[k], λ...)
+            end
+        end
+    end
+    return ret
+end
+function mutable_operate!(::typeof(add_mul), ret::Matrix{T},
+                          A::AbstractMatrix,
+                          adjB::TransposeOrAdjoint{<:Any, <:SparseMat},
+                          α::Vararg{Union{T, Scaling}, N}) where {T, N}
+    _dim_check(ret, A, adjB)
+    λ = scaling.(α)
+    B = parent(adjB)
+    B_rowvals = SparseArrays.rowvals(B)
+    B_nonzeros = SparseArrays.nonzeros(B)
+    for B_col ∈ 1:size(B, 2), k ∈ SparseArrays.nzrange(B, B_col)
+        B_row = B_rowvals[k]
+        B_val = _mirror_transpose_or_adjoint(B_nonzeros[k], adjB)
+        αB_val = *(B_val, λ...)
+        for A_row in 1:size(A, 1)
+            mutable_operate!(add_mul, ret[A_row, B_row], A[A_row, B_col], αB_val)
+        end
+    end
+    return ret
+end
+
+# TODO
+#function _densify_with_jump_eltype(x::SparseMat{V}) where {V <: AbstractVariableRef}
+#    return convert(Matrix{GenericAffExpr{Float64, V}}, x)
+#end
+#_densify_with_jump_eltype(x::AbstractMatrix) = convert(Matrix, x)
+#
+## TODO: Implement sparse * sparse code as in base/sparse/linalg.jl (spmatmul).
+#function _mul!(ret::AbstractMatrix{<:AbstractMutable},
+#               A::SparseMat,
+#               B::SparseMat)
+#    return mul!(ret, A, _densify_with_jump_eltype(B))
+#end
+#
+## TODO: Implement sparse * sparse code as in base/sparse/linalg.jl (spmatmul).
+#function _mul!(ret::AbstractMatrix{<:AbstractMutable},
+#               A::TransposeOrAdjoint{<:Any, <:SparseMat},
+#               B::SparseMat)
+#    return mul!(ret, A, _densify_with_jump_eltype(B))
+#end
+#
+## TODO: Implement sparse * sparse code as in base/sparse/linalg.jl (spmatmul).
+#function _mul!(ret::AbstractMatrix{<:AbstractMutable},
+#               A::SparseMat,
+#               B::TransposeOrAdjoint{<:Any, <:SparseMat})
+#    return mul!(ret, _densify_with_jump_eltype(A), B)
+#end

--- a/test/dummy.jl
+++ b/test/dummy.jl
@@ -1,0 +1,44 @@
+# It does not support operation with floats on purpose to test that
+# MutableArithmetics does not convert to float when it shouldn't.
+struct DummyBigInt <: MA.AbstractMutable
+    data::BigInt
+end
+DummyBigInt(J::UniformScaling) = DummyBigInt(J.λ)
+Base.broadcastable(x::DummyBigInt) = Ref(x)
+Base.promote_rule(::Type{DummyBigInt}, ::Type{<:Union{Integer, UniformScaling{<:Integer}}}) = DummyBigInt
+# `copy` on BigInt returns the same instance anyway
+Base.copy(x::DummyBigInt) = x
+LinearAlgebra.symmetric_type(::Type{DummyBigInt}) = DummyBigInt
+LinearAlgebra.symmetric(x::DummyBigInt, ::Symbol) = x
+LinearAlgebra.dot(x::DummyBigInt, y::DummyBigInt) = x * y
+LinearAlgebra.dot(x::DummyBigInt, y::Union{Integer, UniformScaling{<:Integer}}) = x * y
+LinearAlgebra.dot(x::Union{Integer, UniformScaling{<:Integer}}, y::DummyBigInt) = x * y
+LinearAlgebra.transpose(x::DummyBigInt) = x
+LinearAlgebra.adjoint(x::DummyBigInt) = x
+MA.mutability(::Type{DummyBigInt}) = MA.IsMutable()
+MA.promote_operation(::typeof(zero), ::Type{DummyBigInt}) = DummyBigInt
+MA.promote_operation(::typeof(one), ::Type{DummyBigInt}) = DummyBigInt
+MA.promote_operation(::typeof(+), ::Type{DummyBigInt}, ::Type{DummyBigInt}) = DummyBigInt
+_data(x) = x
+_data(x::DummyBigInt) = x.data
+MA.scaling(x::DummyBigInt) = x
+MA.mutable_operate_to!(x::DummyBigInt, op::Function, args...) = DummyBigInt(MA.mutable_operate_to!(x.data, op, _data.(args)...))
+MA.mutable_operate!(op::Union{typeof(zero), typeof(one)}, x::DummyBigInt, args...) = DummyBigInt(MA.mutable_operate!(op, x.data, _data.(args)...))
+MA.promote_operation(::typeof(*), ::Type{DummyBigInt}, ::Type{DummyBigInt}) = DummyBigInt
+Base.convert(::Type{DummyBigInt}, x::Int) = DummyBigInt(x)
+Base.:(==)(x::DummyBigInt, y::DummyBigInt) = x.data == y.data
+Base.zero(::Union{DummyBigInt, Type{DummyBigInt}}) = DummyBigInt(zero(BigInt))
+Base.one(::Union{DummyBigInt, Type{DummyBigInt}}) = DummyBigInt(one(BigInt))
+Base.:+(x::DummyBigInt) = DummyBigInt(+x.data)
+Base.:+(x::DummyBigInt, y::DummyBigInt) = DummyBigInt(x.data + y.data)
+Base.:+(x::DummyBigInt, y::Union{Integer, UniformScaling{<:Integer}}) = DummyBigInt(x.data + y)
+Base.:+(x::Union{Integer, UniformScaling{<:Integer}}, y::DummyBigInt) = DummyBigInt(x + y.data)
+Base.:-(x::DummyBigInt) = DummyBigInt(-x.data)
+Base.:-(x::DummyBigInt, y::DummyBigInt) = DummyBigInt(x.data - y.data)
+Base.:-(x::Union{Integer, UniformScaling{<:Integer}}, y::DummyBigInt) = DummyBigInt(x - y.data)
+Base.:-(x::DummyBigInt, y::Union{Integer, UniformScaling{<:Integer}}) = DummyBigInt(x.data - y)
+Base.:*(x::DummyBigInt) = x
+Base.:*(x::DummyBigInt, y::DummyBigInt) = DummyBigInt(x.data * y.data)
+Base.:*(x::Union{Integer, UniformScaling{<:Integer}}, y::DummyBigInt) = DummyBigInt(x * y.data)
+Base.:*(x::DummyBigInt, y::Union{Integer, UniformScaling{<:Integer}}) = DummyBigInt(x.data * y)
+Base.:^(x::DummyBigInt, y::Union{Integer, UniformScaling{<:Integer}}) = DummyBigInt(x.data ^ y)

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -1,26 +1,61 @@
+using Test
+import MutableArithmetics
+const MA = MutableArithmetics
+
+include("utilities.jl")
+
 @testset "Matrix multiplication" begin
-	@testset "matrix-vector product" begin
-		A = BigInt[1 1 1; 1 1 1; 1 1 1]
-		x = BigInt[1; 1; 1]
-		y = BigInt[0; 0; 0]
+    @testset "matrix-vector product" begin
+        A = [1 1 1; 1 1 1; 1 1 1]
+        x = [1; 1; 1]
+        y = [0; 0; 0]
 
-		@test MA.mul(A, x) == BigInt[3; 3; 3]
-		@test MA.mul_to!(y, A, x) == BigInt[3; 3; 3] && y == BigInt[3; 3; 3]
+        @test MA.mul(A, x) == [3; 3; 3]
+        @test MA.mul_to!(y, A, x) == [3; 3; 3] && y == [3; 3; 3]
 
-		A = BigInt[1 1 1; 1 1 1; 1 1 1]
-		x = BigInt[1; 1; 1]
-		y = BigInt[0; 0; 0]
+        A = BigInt[1 1 1; 1 1 1; 1 1 1]
+        x = BigInt[1; 1; 1]
+        y = BigInt[0; 0; 0]
 
-		@test MA.mutability(y, *, A, x) isa MA.IsMutable
-		@test MA.mul(A, x) == BigInt[3; 3; 3]
-		@test MA.mul_to!(y, A, x) == BigInt[3; 3; 3] && y == BigInt[3; 3; 3]
-		@test_throws DimensionMismatch MA.mul(BigInt[1 1; 1 1], BigInt[])
-		@test_throws DimensionMismatch MA.mul_to!(BigInt[], BigInt[1 1; 1 1], BigInt[1; 1])
+        @test MA.mutability(y, *, A, x) isa MA.IsMutable
+        @test MA.mul(A, x) == BigInt[3; 3; 3]
+        @test MA.mul_to!(y, A, x) == BigInt[3; 3; 3] && y == BigInt[3; 3; 3]
+        @test_throws DimensionMismatch MA.mul(BigInt[1 1; 1 1], BigInt[])
+        @test_throws DimensionMismatch MA.mul_to!(BigInt[], BigInt[1 1; 1 1], BigInt[1; 1])
 
         # 40 bytes to create the buffer
         # 8 bytes in the double for loop. FIXME: figure out why
-        alloc_test(() -> MA.mul_to!(y, A, x), 48)
-        alloc_test(() -> MA.operate_to!(y, *, A, x), 48)
-        alloc_test(() -> MA.mutable_operate_to!(y, *, A, x), 48)
-	end
+        alloc_test(() -> MA.add_mul!(y, A, x), 48)
+        alloc_test(() -> MA.operate!(MA.add_mul, y, A, x), 48)
+        alloc_test(() -> MA.mutable_operate!(MA.add_mul, y, A, x), 48)
+    end
+    @testset "matrix-matrix product" begin
+        A = [1 2 3; 4 5 6; 6 8 9]
+        B = [1 -1 2; -2 3 1; 2 -3 1]
+        C = [one(Int) for i in 1:3, j in 1:3]
+
+        D = [3 -4 7; 6 -7 19; 8 -9 29]
+        @test MA.mul(A, B) == D
+        @test MA.mul_to!(C, A, B) == D
+        @test C == D
+
+        A = BigInt[1 2 3; 4 5 6; 6 8 9]
+        B = BigInt[1 -1 2; -2 3 1; 2 -3 1]
+        C = [one(BigInt) for i in 1:3, j in 1:3]
+
+        D = BigInt[3 -4 7; 6 -7 19; 8 -9 29]
+        @test MA.mul(A, B) == D
+        @test MA.mul_to!(C, A, B) == D
+        @test C == D
+
+        @test MA.mutability(C, *, A, B) isa MA.IsMutable
+        @test_throws DimensionMismatch MA.mul(BigInt[1 1; 1 1], zeros(BigInt, 1, 1))
+        @test_throws DimensionMismatch MA.mul_to!(zeros(BigInt, 1, 1), BigInt[1 1; 1 1], zeros(BigInt, 2, 1))
+
+        # 40 bytes to create the buffer
+        # 8 bytes in the double for loop. FIXME: figure out why
+        alloc_test(() -> MA.add_mul!(C, A, B), 48)
+        alloc_test(() -> MA.operate!(MA.add_mul, C, A, B), 48)
+        alloc_test(() -> MA.mutable_operate!(MA.add_mul, C, A, B), 48)
+    end
 end

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -23,9 +23,18 @@ include("utilities.jl")
         @test_throws DimensionMismatch MA.mul(BigInt[1 1; 1 1], BigInt[])
         @test_throws DimensionMismatch MA.mul_to!(BigInt[], BigInt[1 1; 1 1], BigInt[1; 1])
 
+        @testset "mutability" begin
+            alloc_test(() -> MA.promote_operation(*, typeof(A), typeof(x)), 0)
+            alloc_test(() -> MA.promote_operation(+, typeof(y), MA.promote_operation(*, typeof(A), typeof(x))), 0)
+            alloc_test(() -> MA.promote_operation(MA.add_mul, typeof(y), typeof(A), typeof(x)), 0)
+            alloc_test(() -> MA.mutability(typeof(y), MA.add_mul, typeof(y), typeof(A), typeof(x)), 0)
+            alloc_test(() -> MA.mutability(y, MA.add_mul, y, A, x), 0)
+        end
+
         # 40 bytes to create the buffer
         # 8 bytes in the double for loop. FIXME: figure out why
         alloc_test(() -> MA.add_mul!(y, A, x), 48)
+        alloc_test(() -> MA.operate_fallback!(MA.IsMutable(), MA.add_mul, y, A, x), 48)
         alloc_test(() -> MA.operate!(MA.add_mul, y, A, x), 48)
         alloc_test(() -> MA.mutable_operate!(MA.add_mul, y, A, x), 48)
     end
@@ -51,6 +60,14 @@ include("utilities.jl")
         @test MA.mutability(C, *, A, B) isa MA.IsMutable
         @test_throws DimensionMismatch MA.mul(BigInt[1 1; 1 1], zeros(BigInt, 1, 1))
         @test_throws DimensionMismatch MA.mul_to!(zeros(BigInt, 1, 1), BigInt[1 1; 1 1], zeros(BigInt, 2, 1))
+
+        @testset "mutability" begin
+            alloc_test(() -> MA.promote_operation(*, typeof(A), typeof(B)), 0)
+            alloc_test(() -> MA.promote_operation(+, typeof(C), MA.promote_operation(*, typeof(A), typeof(B))), 0)
+            alloc_test(() -> MA.promote_operation(MA.add_mul, typeof(C), typeof(A), typeof(B)), 0)
+            alloc_test(() -> MA.mutability(typeof(C), MA.add_mul, typeof(C), typeof(A), typeof(B)), 0)
+            alloc_test(() -> MA.mutability(C, MA.add_mul, C, A, B), 0)
+        end
 
         # 40 bytes to create the buffer
         # 8 bytes in the double for loop. FIXME: figure out why

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -182,9 +182,11 @@ function sum_test(matrix)
     end
     @testset "sum(affs::Array{AffExpr})" begin
         @test_rewrite sum([2matrix[i, j] for i in 1:size(matrix, 1), j in 1:size(matrix, 2)])
+        @test_rewrite sum(2matrix[i, j] for i in 1:size(matrix, 1), j in 1:size(matrix, 2))
     end
     @testset "sum(quads::Array{QuadExpr})" begin
         @test_rewrite sum([2matrix[i, j]^2 for i in 1:size(matrix, 1), j in 1:size(matrix, 2)])
+        @test_rewrite sum(2matrix[i, j]^2 for i in 1:size(matrix, 1), j in 1:size(matrix, 2))
     end
 end
 

--- a/test/rewrite.jl
+++ b/test/rewrite.jl
@@ -1,4 +1,4 @@
-using SparseArrays, Test
+using LinearAlgebra, SparseArrays, Test
 import MutableArithmetics
 const MA = MutableArithmetics
 
@@ -8,13 +8,18 @@ macro test_rewrite(expr)
     end)
 end
 
-function basic_operators_test(w, x, y, z)
-    aff = @inferred 7.1 * x + 2.5
-    @test_rewrite 7.1 * x + 2.5
-    aff2 = @inferred 1.2 * y + 1.2
-    @test_rewrite 1.2 * y + 1.2
-    q = @inferred 2.5 * y * z + aff
-    @test_rewrite 2.5 * y * z + aff
+include("dummy.jl")
+
+function basic_operators_test(w, x, y, z; supports_float = true)
+    a = 7
+    b = 2
+    c = 1
+    aff = @inferred a * x + b
+    @test_rewrite a * x + b
+    aff2 = @inferred c * y + c
+    @test_rewrite c * y + c
+    q = @inferred b * y * z + aff
+    @test_rewrite b * y * z + aff
     q2 = @inferred 8 * x * z + aff2
     @test_rewrite 8 * x * z + aff2
     @test_rewrite 2 * x * x + 1 * y * y + z + 3
@@ -37,11 +42,11 @@ function basic_operators_test(w, x, y, z)
             @test !MA.isequal_canonical(aff, aff2)
             @test !MA.isequal_canonical(aff2, aff)
 
-            @test  MA.isequal_canonical(q, @inferred 2.5z*y + aff)
-            @test !MA.isequal_canonical(q, @inferred 2.5y*z + aff2)
-            @test !MA.isequal_canonical(q, @inferred 2.5x*z + aff)
-            @test !MA.isequal_canonical(q, @inferred 2.5y*x + aff)
-            @test !MA.isequal_canonical(q, @inferred 1.5y*z + aff)
+            @test  MA.isequal_canonical(q, @inferred b*z*y + aff)
+            @test !MA.isequal_canonical(q, @inferred b*y*z + aff2)
+            @test !MA.isequal_canonical(q, @inferred b*x*z + aff)
+            @test !MA.isequal_canonical(q, @inferred b*y*x + aff)
+            @test !MA.isequal_canonical(q, @inferred (b-1)*y*z + aff)
             @test  MA.isequal_canonical(q2, @inferred 8z*x + aff2)
             @test !MA.isequal_canonical(q2, @inferred 8x*z + aff)
             @test !MA.isequal_canonical(q2, @inferred 7x*z + aff2)
@@ -60,16 +65,16 @@ function basic_operators_test(w, x, y, z)
     @testset "Number--???" begin
         # 1-1 Number--Number - nope!
         # 1-2 Number--Variable
-        @test_rewrite 4.13 + w
-        @test_rewrite 3.16 - w
-        @test_rewrite 5.23 * w
+        @test_rewrite 4 + w
+        @test_rewrite 3 - w
+        @test_rewrite 5 * w
         # 1-3 Number--AffExpr
-        @test_rewrite 1.5 + aff
-        @test_rewrite 1.5 - aff
+        @test_rewrite 1 + aff
+        @test_rewrite 1 - aff
         @test_rewrite 2 * aff
         # 1-4 Number--QuadExpr
-        @test_rewrite 1.5 + q
-        @test_rewrite 1.5 - q
+        @test_rewrite 1 + q
+        @test_rewrite 1 - q
         @test_rewrite 2 * q
     end
 
@@ -79,10 +84,12 @@ function basic_operators_test(w, x, y, z)
         @test (+x) === x
         @test_rewrite -x
         # 2-1 Variable--Number
-        @test_rewrite w + 4.13
-        @test_rewrite w - 4.13
-        @test_rewrite w * 4.13
-        @test_rewrite w / 2.00
+        @test_rewrite w + 4
+        @test_rewrite w - 4
+        @test_rewrite w * 4
+        if supports_float
+            @test_rewrite w / 2
+        end
         @test w == w
         @test_rewrite x*y - 1
         @test_rewrite x^2
@@ -98,7 +105,7 @@ function basic_operators_test(w, x, y, z)
         @test_rewrite z + aff
         @test_rewrite z - aff
         @test_rewrite z * aff
-        @test_rewrite 7.1 * x - aff
+        @test_rewrite 7 * x - aff
         # 2-4 Variable--QuadExpr
         @test_rewrite w + q
         @test_rewrite w - q
@@ -110,23 +117,25 @@ function basic_operators_test(w, x, y, z)
         @test_rewrite +aff
         @test_rewrite -aff
         # 3-1 AffExpr--Number
-        @test_rewrite aff + 1.5
-        @test_rewrite aff - 1.5
+        @test_rewrite aff + 1
+        @test_rewrite aff - 1
         @test_rewrite aff * 2
-        @test_rewrite aff / 2
+        if supports_float
+            @test_rewrite aff / 2
+        end
         @test aff == aff
         @test_rewrite aff - 1
         @test_rewrite aff^2
-        @test_rewrite (7.1*x + 2.5)^2
+        @test_rewrite (a*x + b)^2
         @test_rewrite aff^1
-        @test_rewrite (7.1*x + 2.5)^1
+        @test_rewrite (a*x + b)^1
         @test_rewrite aff^0
-        @test_rewrite (7.1*x + 2.5)^0
+        @test_rewrite (a*x + b)^0
         # 3-2 AffExpr--Variable
         @test_rewrite aff + z
         @test_rewrite aff - z
         @test_rewrite aff * z
-        @test_rewrite aff - 7.1 * x
+        @test_rewrite aff - a * x
         # 3-3 AffExpr--AffExpr
         @test_rewrite aff + aff2
         @test_rewrite aff - aff2
@@ -147,10 +156,12 @@ function basic_operators_test(w, x, y, z)
         @test_rewrite +q
         @test_rewrite -q
         # 4-1 QuadExpr--Number
-        @test_rewrite q + 1.5
-        @test_rewrite q - 1.5
+        @test_rewrite q + 1
+        @test_rewrite q - 1
         @test_rewrite q * 2
-        @test_rewrite q / 2
+        if supports_float
+            @test_rewrite q / 2
+        end
         @test q == q
         @test_rewrite aff2 - q
         # 4-2 QuadExpr--Variable
@@ -190,20 +201,20 @@ function dot_test(x, y, z)
     @test_rewrite dot(A, y)
     @test_rewrite dot(y, A)
 
-    B = ones(2, 2, 2)
+    B = ones(Int, 2, 2, 2)
     @test_rewrite dot(B, z)
     @test_rewrite dot(z, B)
 
-    @test_rewrite dot(x, ones(3)) - dot(y, ones(2,2))
+    @test_rewrite dot(x, ones(Int, 3)) - dot(y, ones(Int, 2, 2))
 end
 
 # JuMP issue #656
 function issue_656(x)
-    floats = Float64[i for i in 1:2]
+    ints = [i for i in 1:2]
     anys   = Array{Any}(undef, 2)
     anys[1] = 10
     anys[2] = 20 + x
-    @test dot(floats, anys) == 10 + 40 + 2x
+    @test dot(ints, anys) == 10 + 40 + 2x
 end
 
 function transpose_test(x, y, z)
@@ -220,7 +231,7 @@ function transpose_test(x, y, z)
     @test transpose(transpose(z)) == z
 end
 
-function vectorized_test(x, X11, X23, Xd)
+function vectorized_test(x, X11, X23, Xd; supports_float = true)
     A = [2 1 0
          1 2 1
          0 1 2]
@@ -250,6 +261,7 @@ function vectorized_test(x, X11, X23, Xd)
         @test_rewrite(Xd + Yd)
         @test_rewrite(Xd - Yd)
         @test_rewrite(Xd + 2Yd)
+
         @test_rewrite(Xd - 2Yd)
         @test_rewrite(Xd + Yd * 2)
         @test_rewrite(Xd - Yd * 2)
@@ -273,10 +285,10 @@ function vectorized_test(x, X11, X23, Xd)
     @test_rewrite(x')
     @test_rewrite(x' * A)
     # Complex expression
-    @test_rewrite(x' * ones(3, 3))
+    @test_rewrite(x' * ones(Int, 3, 3))
     @test_rewrite(x' * A * x)
     # Complex expression
-    @test_rewrite(x' * ones(3, 3) * x)
+    @test_rewrite(x' * ones(Int, 3, 3) * x)
 
     @test MA.isequal_canonical(A*x, [2x[1] +  x[2]
                        2x[2] +  x[1] + x[3]
@@ -295,26 +307,30 @@ function vectorized_test(x, X11, X23, Xd)
 
     y = A*x
     @test MA.isequal_canonical(-x, [-x[1], -x[2], -x[3]])
-    @test MA.isequal_canonical(-y, [-2x[1] -  x[2]
-                       -x[1] - 2x[2] -  x[3]
-                               -x[2] - 2x[3]])
-    @test MA.isequal_canonical(y .+ 1, [2x[1] +  x[2]         + 1
-                          x[1] + 2x[2] +  x[3] + 1
-                          x[2] + 2x[3] + 1])
+    @test MA.isequal_canonical(-y, [
+        -2x[1] -  x[2]
+         -x[1] - 2x[2] -  x[3]
+                 -x[2] - 2x[3]])
+    @test MA.isequal_canonical(y .+ 1, [
+        2x[1] +  x[2]         + 1
+         x[1] + 2x[2] +  x[3] + 1
+                 x[2] + 2x[3] + 1])
     @test MA.isequal_canonical(y .- 1, [
         2x[1] +  x[2]         - 1
          x[1] + 2x[2] +  x[3] - 1
                  x[2] + 2x[3] - 1])
-    @test MA.isequal_canonical(y .+ 2ones(3), [2x[1] +  x[2]         + 2
+    @test MA.isequal_canonical(y .+ 2ones(Int, 3), [
+        2x[1] +  x[2]         + 2
+         x[1] + 2x[2] +  x[3] + 2
+                 x[2] + 2x[3] + 2])
+    @test MA.isequal_canonical(y .- 2ones(Int, 3), [
+        2x[1] +  x[2]         - 2
+         x[1] + 2x[2] +  x[3] - 2
+                 x[2] + 2x[3] - 2])
+    @test MA.isequal_canonical(2ones(Int, 3) .+ y, [2x[1] +  x[2]         + 2
                                  x[1] + 2x[2] +  x[3] + 2
                                  x[2] + 2x[3] + 2])
-    @test MA.isequal_canonical(y .- 2ones(3), [2x[1] +  x[2]         - 2
-                                 x[1] + 2x[2] +  x[3] - 2
-                                 x[2] + 2x[3] - 2])
-    @test MA.isequal_canonical(2ones(3) .+ y, [2x[1] +  x[2]         + 2
-                                 x[1] + 2x[2] +  x[3] + 2
-                                 x[2] + 2x[3] + 2])
-    @test MA.isequal_canonical(2ones(3) .- y, [-2x[1] -  x[2]         + 2
+    @test MA.isequal_canonical(2ones(Int, 3) .- y, [-2x[1] -  x[2]         + 2
                                  -x[1] - 2x[2] -  x[3] + 2
                                  -x[2] - 2x[3] + 2])
     @test MA.isequal_canonical(y .+ x, [3x[1] +  x[2]
@@ -339,30 +355,38 @@ function vectorized_test(x, X11, X23, Xd)
                              x[1] + 3x[2] +  x[3]
                                      x[2] + 3x[3]])
 
-    @test MA.isequal_canonical(MA.@rewrite(A*x/2), A*x/2)
+    if supports_float
+        @test MA.isequal_canonical(MA.@rewrite(A*x/2), A*x/2)
+    end
     @test MA.isequal_canonical(X*v,  [4X11; 6X23; 0])
     @test MA.isequal_canonical(v'*X,  [4X11  0   5X23])
     @test MA.isequal_canonical(copy(transpose(v))*X, [4X11  0   5X23])
     @test MA.isequal_canonical(X'*v,  [4X11;  0;  5X23])
     @test MA.isequal_canonical(copy(transpose(X))*v, [4X11; 0;  5X23])
-    @test MA.isequal_canonical(X*A,  [2X11  X11  0
-                        0     X23  2X23
-                        0     0    0   ])
-    @test MA.isequal_canonical(A*X,  [2X11  0    X23
-                        X11   0    2X23
-                        0     0    X23])
-    @test MA.isequal_canonical(A*X', [2X11  0    0
-                        X11   X23  0
-                        0     2X23 0])
-    @test MA.isequal_canonical(X'*A, [2X11  X11  0
-                        0     0    0
-                        X23   2X23 X23])
-    @test MA.isequal_canonical(copy(transpose(X))*A, [2X11 X11  0
-                         0    0    0
-                         X23  2X23 X23])
-    @test MA.isequal_canonical(A'*X, [2X11  0 X23
-                        X11   0 2X23
-                        0     0 X23])
+    @test MA.isequal_canonical(X*A,  [
+        2X11  X11  0
+        0     X23  2X23
+        0     0    0   ])
+    @test MA.isequal_canonical(A*X,  [
+        2X11  0    X23
+        X11   0    2X23
+        0     0    X23])
+    @test MA.isequal_canonical(A*X', [
+        2X11  0    0
+         X11   X23  0
+        0     2X23 0])
+    @test MA.isequal_canonical(X'*A, [
+        2X11  X11  0
+         0     0    0
+         X23   2X23 X23])
+    @test MA.isequal_canonical(copy(transpose(X))*A, [
+        2X11 X11  0
+         0    0    0
+         X23  2X23 X23])
+    @test MA.isequal_canonical(A'*X, [
+        2X11  0 X23
+         X11   0 2X23
+         0     0 X23])
     @test MA.isequal_canonical(copy(transpose(X))*A, X'*A)
     @test MA.isequal_canonical(copy(transpose(A))*X, A'*X)
     @test MA.isequal_canonical(X*A, X*B)
@@ -392,7 +416,7 @@ function vectorized_test(x, X11, X23, Xd)
     end
 end
 
-function broadcast_test(x)
+function broadcast_test(x; supports_float = true)
     A = [1 2;
          3 4]
     B = sparse(A)
@@ -432,11 +456,13 @@ function broadcast_test(x)
     @test MA.isequal_canonical(y.*A, y.*B)
 
     @test MA.isequal_canonical(x .* x, [x[1,1]^2 x[1,2]^2; x[2,1]^2 x[2,2]^2])
-    @test MA.isequal_canonical(x ./ A, [
-        x[1,1] / 1  x[1,2] / 2;
-        x[2,1] / 3  x[2,2] / 4])
-    @test MA.isequal_canonical(x ./ A, x ./ B)
-    @test MA.isequal_canonical(x ./ A, y ./ A)
+    if supports_float
+        @test MA.isequal_canonical(x ./ A, [
+                                            x[1,1] / 1  x[1,2] / 2;
+                                            x[2,1] / 3  x[2,2] / 4])
+        @test MA.isequal_canonical(x ./ A, x ./ B)
+        @test MA.isequal_canonical(x ./ A, y ./ A)
+    end
 
     # TODO: Refactor to avoid calling the internal JuMP function
     # `_densify_with_jump_eltype`.
@@ -466,7 +492,7 @@ function non_array_test(x, x2)
     end
     # `diagm` only define with `Pair` in Julia v1.0 and v1.1
     @testset "diagm" begin
-        if !MA._one_indexed(x2) && eltype(x2) isa MA.AbstractMutable
+        if !MA._one_indexed(x2) && eltype(x2) <: MA.AbstractMutable
             @test_throws AssertionError diagm(x2)
         else
             @test diagm(0 => x) == diagm(0 => x2)
@@ -517,29 +543,50 @@ end
 using LinearAlgebra
 using OffsetArrays
 
-@testset "@rewrite with $T" for T in [
-        Int,
-        Float64,
-        BigInt
+@testset "@rewrite with $T" for (T, supports_float) in [
+        (Int, true),
+        (Float64, true),
+        (BigInt, true),
+        (DummyBigInt, false)
     ]
-    basic_operators_test(T(1), T(2), T(3), T(4))
-    sum_test(T[5 1 9; -7 2 4; -2 -7 5])
-    S = zeros(T, 2, 2, 2)
-    S[1, :, :] = T[5 -8; 3 -7]
-    S[2, :, :] = T[-2 8; 8 -1]
-    dot_test(T[-7, 1, 4], T[0 -4; 6 -5], S)
-    issue_656(T(3))
-    transpose_test(T[9, -3, 8], T[-4 4 1; 4 -8 -6], T[6, 9, 2, 4, -3])
-    vectorized_test(T[3, 2, 6], T(4), T(5), T[8 1 9; 4 3 1; 2 0 8])
-    broadcast_test(T[2 4; -1 3])
-    x = T[2, 4, 3]
-    non_array_test(x, x)
-    non_array_test(x, OffsetArray(x, -length(x)))
-    non_array_test(x, view(x, :))
-    non_array_test(x, sparse(x))
-    unary_matrix(T[1 2; 3 4])
-    unary_matrix(Symmetric(T[1 2; 2 4]))
-    scalar_uniform_scaling(T(3))
-    matrix_uniform_scaling(T[1 2; 3 4])
-    matrix_uniform_scaling(Symmetric(T[1 2; 2 4]))
+    @testset "Basic" begin
+        basic_operators_test(T(1), T(2), T(3), T(4), supports_float = supports_float)
+    end
+    @testset "Sum" begin
+        sum_test(T[5 1 9; -7 2 4; -2 -7 5])
+    end
+    @testset "Dot" begin
+        S = zeros(T, 2, 2, 2)
+        S[1, :, :] = T[5 -8; 3 -7]
+        S[2, :, :] = T[-2 8; 8 -1]
+        dot_test(T[-7, 1, 4], T[0 -4; 6 -5], S)
+    end
+    @testset "Issue 656" begin
+        issue_656(T(3))
+    end
+    @testset "Transpose" begin
+        transpose_test(T[9, -3, 8], T[-4 4 1; 4 -8 -6], T[6, 9, 2, 4, -3])
+    end
+    @testset "Vectorized" begin
+        vectorized_test(T[3, 2, 6], T(4), T(5), T[8 1 9; 4 3 1; 2 0 8], supports_float = supports_float)
+    end
+    @testset "Broadcast" begin
+        broadcast_test(T[2 4; -1 3], supports_float = supports_float)
+    end
+    @testset "Non-array" begin
+        x = T[2, 4, 3]
+        non_array_test(x, x)
+        non_array_test(x, OffsetArray(x, -length(x)))
+        non_array_test(x, view(x, :))
+        non_array_test(x, sparse(x))
+    end
+    @testset "Unary" begin
+        unary_matrix(T[1 2; 3 4])
+        unary_matrix(Symmetric(T[1 2; 2 4]))
+    end
+    @testset "Uniform Scaling" begin
+        scalar_uniform_scaling(T(3))
+        matrix_uniform_scaling(T[1 2; 3 4])
+        matrix_uniform_scaling(Symmetric(T[1 2; 2 4]))
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,10 +2,7 @@ using Test
 import MutableArithmetics
 const MA = MutableArithmetics
 
-function alloc_test(f, n)
-    f() # compile
-    @test n == @allocated f()
-end
+include("utilities.jl")
 
 @testset "Int" begin
     include("int.jl")

--- a/test/utilities.jl
+++ b/test/utilities.jl
@@ -1,0 +1,4 @@
+function alloc_test(f, n)
+    f() # compile
+    @test n == @allocated f()
+end


### PR DESCRIPTION
Generalises JuMP's rewrite of some linear algebra operation on dense and sparse arrays to arbitrary mutable types.