### PR TITLE
Add operate function

### DIFF
--- a/src/MutableArithmetics.jl
+++ b/src/MutableArithmetics.jl
@@ -52,6 +52,8 @@ scaling_convert(T::Type, x::LinearAlgebra.UniformScaling) = convert(T, x.λ)
 scaling_convert(T::Type, x) = convert(T, x)
 include("bigint.jl")
 include("bigfloat.jl")
+
+include("reduce.jl")
 include("linear_algebra.jl")
 include("sparse_arrays.jl")
 

--- a/src/linear_algebra.jl
+++ b/src/linear_algebra.jl
@@ -251,7 +251,7 @@ function operate(::typeof(*), x::LinearAlgebra.Transpose{<:Any, <:AbstractVector
         throw(DimensionMismatch("first array has length $(lx) which does not match the length of the second, $(length(y))."))
     end
     if iszero(lx)
-        return promote_operation(add_mul, eltype(x), eltype(y))
+        return zero(promote_operation(add_mul, eltype(x), eltype(y)))
     end
 
     # We need a buffer to hold the intermediate multiplication.

--- a/src/reduce.jl
+++ b/src/reduce.jl
@@ -1,0 +1,3 @@
+function operate(::typeof(sum), a::AbstractArray)
+    return mapreduce(identity, add!, a, init = zero(promote_operation(+, eltype(a), eltype(a))))
+end

--- a/src/rewrite.jl
+++ b/src/rewrite.jl
@@ -26,11 +26,14 @@ macro rewrite(expr)
 end
 
 struct Zero end
-# We need to copy `x` as it will be used as might be given by the user and be
-# given as first argument of `operate!`.
-Base.:(+)(zero::Zero, x) = copy_if_mutable(x)
-# `add_mul(zero, ...)` redirects to `muladd(..., zero)` which calls `... + zero`.
-Base.:(+)(x, zero::Zero) = copy_if_mutable(x)
+## We need to copy `x` as it will be used as might be given by the user and be
+## given as first argument of `operate!`.
+#Base.:(+)(zero::Zero, x) = copy_if_mutable(x)
+## `add_mul(zero, ...)` redirects to `muladd(..., zero)` which calls `... + zero`.
+#Base.:(+)(x, zero::Zero) = copy_if_mutable(x)
+function operate(::typeof(add_mul), ::Zero, args::Vararg{Any, N}) where {N}
+    return operate(*, args...)
+end
 broadcast!(::Union{typeof(add_mul), typeof(+)}, ::Zero, x) = copy_if_mutable(x)
 broadcast!(::typeof(add_mul), ::Zero, x, y) = x * y
 

--- a/src/shortcuts.jl
+++ b/src/shortcuts.jl
@@ -26,6 +26,14 @@ Return the product of `a`, `b`, ..., possibly modifying `a`.
 """
 mul!(args::Vararg{Any, N}) where {N} = operate!(*, args...)
 
+"""
+    mul(a, b, ...)
+
+Shortcut for `operate(*, a, b, ...)`, see [`operate`](@ref).
+"""
+mul(args::Vararg{Any, N}) where {N} = operate(*, args...)
+
+
 # `Vararg` gives extra allocations on Julia v1.3, see https://travis-ci.com/JuliaOpt/MutableArithmetics.jl/jobs/260666164#L215-L238
 function promote_operation(::typeof(add_mul), T::Type, x::Type, y::Type)
     return promote_operation(+, T, promote_operation(*, x, y))

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -58,6 +58,17 @@ end
         B = zeros(2, 2)
         err = DimensionMismatch("Cannot sum matrices of size `(1, 1)` and size `(2, 2)`, the size of the two matrices must be equal.")
         @test_throws err MA.@rewrite A + B
+        x = ones(1)
+        y = ones(2)
+        err = DimensionMismatch("first array has length 1 which does not match the length of the second, 2.")
+        @test_throws err MA.operate(*, x', y)
+        @test_throws err MA.operate(*, LinearAlgebra.transpose(x), y)
+        err = DimensionMismatch("matrix A has dimensions (2,2), vector B has length 1")
+        @test_throws err MA.operate(*, x', B)
+        a = zeros(0)
+        @test iszero(@inferred MA.operate(LinearAlgebra.dot, a, a))
+        @test iszero(@inferred MA.operate(*, a', a))
+        @test iszero(@inferred MA.operate(*, LinearAlgebra.transpose(a), a))
     end
 end
 

--- a/test/matmul.jl
+++ b/test/matmul.jl
@@ -8,6 +8,32 @@ struct CustomArray{T, N} <: AbstractArray{T, N} end
 
 import LinearAlgebra
 
+function dot_test(x, y)
+    @test MA.operate(LinearAlgebra.dot, x, y) == LinearAlgebra.dot(x, y)
+    @test MA.operate(LinearAlgebra.dot, y, x) == LinearAlgebra.dot(y, x)
+    @test MA.operate(*, x', y) == x' * y
+    @test MA.operate(*, y', x) == y' * x
+    @test MA.operate(*, LinearAlgebra.transpose(x), y) == LinearAlgebra.transpose(x) * y
+    @test MA.operate(*, LinearAlgebra.transpose(y), x) == LinearAlgebra.transpose(y) * x
+end
+
+@testset "dot" begin
+    x = [1im]
+    y = [1]
+    A = reshape(x, 1, 1)
+    B = reshape(y, 1, 1)
+    dot_test(x, x)
+    dot_test(y, y)
+    dot_test(A, A)
+    dot_test(B, B)
+    dot_test(x, y)
+    dot_test(x, A)
+    dot_test(x, B)
+    dot_test(y, A)
+    dot_test(y, B)
+    dot_test(A, B)
+end
+
 @testset "promote_operation" begin
     x = [1]
     @test MA.promote_operation(*, typeof(x'), typeof(x)) == Int


### PR DESCRIPTION
This also improves performance of `@rewrite` as `@rewrite(x * y + z)` does not call `copy_if_mutable` on `x * y`, it instead call `operate(*, x, y)`.